### PR TITLE
Use the Unix file ending

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,7 @@ root = true
 [*]
 indent_style = space
 indent_size = 2
-end_of_line = crlf
+end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true


### PR DESCRIPTION
All the files are using the Unix line ending but the `.editorconfig` is with windows line ending.

Without this my editor keeps changing the line ending and messing up the git diffs.