### PR TITLE
Add default values for Second's missing properties

### DIFF
--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -351,10 +351,10 @@ export default Vue.extend({
           this.videoViewCount = result.viewCount
           this.videoLikeCount = result.likeCount
           this.videoDislikeCount = result.dislikeCount
-          this.channelSubscriptionCountText = result.subCountText
+          this.channelSubscriptionCountText = result.subCountText || 'FT-0'
           this.channelId = result.authorId
           this.channelName = result.author
-          this.channelThumbnail = result.authorThumbnails[1].url
+          this.channelThumbnail = result.authorThumbnails[1] ? result.authorThumbnails[1].url : ''
           this.videoPublished = result.published * 1000
           this.videoDescriptionHtml = result.descriptionHtml
           this.recommendedVideos = result.recommendedVideos


### PR DESCRIPTION
If using Second as the API, it's currently missing these properties. This pull request provides default values for them so that the video will still load.

If either the local API or actual Invidious is being used, nothing will be different.