### PR TITLE
Fixed size of subtitle translations submenu, so that it is wide enoug…

### DIFF
--- a/src/renderer/videoJS.css
+++ b/src/renderer/videoJS.css
@@ -1910,7 +1910,7 @@ video::-webkit-media-text-track-display {
 
 .video-js .vjs-menu-button-popup .vjs-menu .vjs-menu-content {
     background-color: transparent;
-    width: 5.5em;
+    width: 7.5em;
     left: 1.5em;
     padding-bottom: .5em;
     z-index: 1;


### PR DESCRIPTION
The field for the automatically generated subtitle did not display the whole string because the boxes were not wide enough. 
Added a bit to fix that.