### PR TITLE
Localization of 'Published x y ago' strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ dist
 coverage
 __coverage__
 csak-timelog.json
+.idea/

--- a/src/renderer/components/ft-list-video/ft-list-video.js
+++ b/src/renderer/components/ft-list-video/ft-list-video.js
@@ -215,10 +215,14 @@ export default Vue.extend({
 
       if (typeof (this.data.publishedText) !== 'undefined') {
         // produces a string according to the template in the locales string
-        this.toLocaleStringS({
+        this.toLocalePublicationString({
           publishText: this.data.publishedText,
           templateString: this.$t('Video.Publicationtemplate'),
-          timeStrings: this.$t('Video.Published')
+          timeStrings: this.$t('Video.Published'),
+          liveStreamString: this.$t('Video.Watching'),
+          upcomingString: this.$t('Video.Published.Upcoming'),
+          isLive: this.data.live,
+          isUpcoming: this.data.isUpcoming
         }).then((data) => {
           this.uploadedTime = data
         }).catch((error) => {
@@ -262,6 +266,19 @@ export default Vue.extend({
       }
 
       if (typeof (this.data.uploaded_at) !== 'undefined') {
+        this.toLocalePublicationString({
+          publishText: this.data.uploaded_at,
+          templateString: this.$t('Video.Publicationtemplate'),
+          timeStrings: this.$t('Video.Published'),
+          liveStreamString: this.$t('Video.Watching'),
+          upcomingString: this.$t('Video.Published.Upcoming'),
+          isLive: this.data.live,
+          isUpcoming: false
+        }).then((data) => {
+          this.uploadedTime = data
+        }).catch((error) => {
+          console.error(error)
+        })
         this.uploadedTime = this.data.uploaded_at
       }
 
@@ -277,7 +294,7 @@ export default Vue.extend({
       this.isLive = this.data.live
     },
     ...mapActions([
-      'toLocaleStringS'
+      'toLocalePublicationString'
     ])
   }
 })

--- a/src/renderer/components/ft-list-video/ft-list-video.js
+++ b/src/renderer/components/ft-list-video/ft-list-video.js
@@ -1,5 +1,6 @@
 import Vue from 'vue'
 import FtIconButton from '../ft-icon-button/ft-icon-button.vue'
+import { mapActions } from 'vuex'
 
 export default Vue.extend({
   name: 'FtListVideo',
@@ -213,7 +214,16 @@ export default Vue.extend({
       this.viewCount = this.data.viewCount
 
       if (typeof (this.data.publishedText) !== 'undefined') {
-        this.uploadedTime = this.data.publishedText
+        // produces a string according to the template in the locales string
+        this.toLocaleStringS({
+          publishText: this.data.publishedText,
+          templateString: this.$t('Video.Publicationtemplate'),
+          timeStrings: this.$t('Video.Published')
+        }).then((data) => {
+          this.uploadedTime = data
+        }).catch((error) => {
+          console.error(error)
+        })
       }
 
       if (typeof (this.data.viewCount) !== 'undefined' && this.data.viewCount !== null) {
@@ -265,6 +275,9 @@ export default Vue.extend({
       }
 
       this.isLive = this.data.live
-    }
+    },
+    ...mapActions([
+      'toLocaleStringS'
+    ])
   }
 })

--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -166,7 +166,13 @@ const actions = {
     return vttString
   },
 
-  toLocaleStringS ({ dispatch }, payload) {
+  toLocalePublicationString ({ dispatch }, payload) {
+    if (payload.isLive) {
+      return '0' + payload.liveStreamString
+    } else if (payload.isUpcoming || payload.publishText === null) {
+      // the check for null is currently just an inferring of knowledge, because there is no other possibility left
+      return payload.upcomingString
+    }
     const strings = payload.publishText.split(' ')
     const singular = (strings[0] === '1')
     let publicationString = payload.templateString.replace('$', strings[0])

--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -166,6 +166,64 @@ const actions = {
     return vttString
   },
 
+  toLocaleStringS ({ dispatch }, payload) {
+    const strings = payload.publishText.split(' ')
+    const singular = (strings[0] === '1')
+    let publicationString = payload.templateString.replace('$', strings[0])
+    switch (strings[1].substring(0, 2)) {
+      case 'se':
+        if (singular) {
+          publicationString = publicationString.replace('%', payload.timeStrings.Second)
+        } else {
+          publicationString = publicationString.replace('%', payload.timeStrings.Seconds)
+        }
+        break
+      case 'mi':
+        if (singular) {
+          publicationString = publicationString.replace('%', payload.timeStrings.Minute)
+        } else {
+          publicationString = publicationString.replace('%', payload.timeStrings.Minutes)
+        }
+        break
+      case 'ho':
+        if (singular) {
+          publicationString = publicationString.replace('%', payload.timeStrings.Hour)
+        } else {
+          publicationString = publicationString.replace('%', payload.timeStrings.Hours)
+        }
+        break
+      case 'da':
+        if (singular) {
+          publicationString = publicationString.replace('%', payload.timeStrings.Day)
+        } else {
+          publicationString = publicationString.replace('%', payload.timeStrings.Days)
+        }
+        break
+      case 'we':
+        if (singular) {
+          publicationString = publicationString.replace('%', payload.timeStrings.Week)
+        } else {
+          publicationString = publicationString.replace('%', payload.timeStrings.Weeks)
+        }
+        break
+      case 'mo':
+        if (singular) {
+          publicationString = publicationString.replace('%', payload.timeStrings.Month)
+        } else {
+          publicationString = publicationString.replace('%', payload.timeStrings.Months)
+        }
+        break
+      case 'ye':
+        if (singular) {
+          publicationString = publicationString.replace('%', payload.timeStrings.Year)
+        } else {
+          publicationString = publicationString.replace('%', payload.timeStrings.Years)
+        }
+        break
+    }
+    return publicationString
+  },
+
   showToast (_, payload) {
     FtToastEvents.$emit('toast.open', payload.message, payload.action, payload.time)
   }

--- a/src/renderer/videoJS.css
+++ b/src/renderer/videoJS.css
@@ -1910,7 +1910,7 @@ video::-webkit-media-text-track-display {
 
 .video-js .vjs-menu-button-popup .vjs-menu .vjs-menu-content {
     background-color: transparent;
-    width: 5.5em;
+    width: 7.5em;
     left: 1.5em;
     padding-bottom: .5em;
     z-index: 1;

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -305,18 +305,22 @@ Video:
     Oct: Okt
     Nov: Nov
     Dec: Dez
+    Second: Sekunde
+    Seconds: Sekunden
     Hour: Stunde
     Hours: Stunden
     Day: Tag
-    Days: Tage
+    Days: Tagen
     Week: Woche
     Weeks: Wochen
     Month: Monat
-    Months: Monate
+    Months: Monaten
     Year: Jahr
-    Years: Jahre
+    Years: Jahren
     Ago: Vor
   Published on: Veröffentlicht am
+  Publicationtemplate: vor $ % veröffentlicht
+
 #& Videos
 Videos:
   #& Sort By

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -318,6 +318,7 @@ Video:
     Year: Jahr
     Years: Jahren
     Ago: Vor
+    Upcoming: Premiere bald
   Published on: Veröffentlicht am
   Publicationtemplate: vor $ % veröffentlicht
 

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -297,6 +297,8 @@ Video:
       Oct: Oct
       Nov: Nov
       Dec: Dec
+      Second: Second
+      Seconds: Seconds
       Hour: Hour
       Hours: Hours
       Day: Day
@@ -309,6 +311,8 @@ Video:
       Years: Years
       Ago: Ago
   Published on: Published on
+  # $ is replaced with the number and % with the unit (days, hours, minutes...)
+  Publicationtemplate: $ % ago
 #& Videos
 Videos:
   #& Sort By

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -310,6 +310,7 @@ Video:
       Year: Year
       Years: Years
       Ago: Ago
+      Upcoming: Premieres soon
   Published on: Published on
   # $ is replaced with the number and % with the unit (days, hours, minutes...)
   Publicationtemplate: $ % ago

--- a/static/locales/pt-PT.yaml
+++ b/static/locales/pt-PT.yaml
@@ -302,6 +302,10 @@ Video:
     Oct: Out
     Nov: Nov
     Dec: Dez
+    # !
+    Second: Second
+    # !
+    Seconds: Seconds
     Hour: Hora
     Hours: Horas
     Day: Dia
@@ -313,7 +317,12 @@ Video:
     Year: Ano
     Years: Anos
     Ago: Há
+    # !
+    Upcoming: Premieres soon
   Published on: Publicado em
+  # !
+  # $ is replaced with the number and % with the unit (days, hours, minutes...)
+  Publicationtemplate: $ % ago
 #& Videos
 Videos:
   #& Sort By


### PR DESCRIPTION
In the ft-list-video.js file, the program makes the calls to the utils.js function with the relevant data from either the Invidious API or local API.
The toLocalePublicationString  in utils.js checks whether the video is a livestream or an upcoming video, and if not, it splits the existing publication string into the relevant parts, checks whether a singular or the plural form of the time unit is required. Then it switch-cases over the first two characters of the time unit of the original publication string and then creates the correct string with the new template string in the localization files.

Fixes first part of #80 but also incorporates the second problem itself