### PR TITLE
Turn the subscriber number into an integer number. 

### DIFF
--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -179,7 +179,7 @@ export default Vue.extend({
       ytch.getChannelInfo(this.id).then((response) => {
         this.id = response.authorId
         this.channelName = response.author
-        this.subCount = response.subscriberCount
+        this.subCount = response.subscriberCount.toFixed(0)
         this.thumbnailUrl = response.authorThumbnails[2].url
         this.channelDescription = autolinker.link(response.description)
         this.relatedChannels = response.relatedChannels


### PR DESCRIPTION
Some channels (e.g. last weeks tonight) had an issue where somehow a very small decimal was added to the subscriber number leading to something like 8.330.000,000.000,001 as subscriber count.

The fix just deletes every decimal place.