### PR TITLE
Fix icon from showing up on certain window systems

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -65,9 +65,9 @@ function createWindow () {
     backgroundColor: '#fff',
     width: 960,
     height: 540,
-    icon: isDev ?
-      path.join(__dirname, '../../_icons/iconColor.png') : 
-      `${__dirname}/_icons/iconColor.png`,
+    icon: isDev
+      ? path.join(__dirname, '../../_icons/iconColor.png')
+      : `${__dirname}/_icons/iconColor.png`,
     autoHideMenuBar: true,
     // useContentSize: true,
     webPreferences: {


### PR DESCRIPTION
Window icon wasn't showing up for me on Arch Linux.

Tested this fix on Arch Linux and Windows 10. Builds and runs without errors on both OS.