### PR TITLE
Fix undesired search suggestions popup

### DIFF
--- a/src/renderer/components/top-nav/top-nav.js
+++ b/src/renderer/components/top-nav/top-nav.js
@@ -17,7 +17,8 @@ export default Vue.extend({
       component: this,
       windowWidth: 0,
       showFilters: false,
-      searchSuggestionsDataList: []
+      searchSuggestionsDataList: [],
+      discardSuggestionsDataOnArrival: false
     }
   },
   computed: {
@@ -73,6 +74,7 @@ export default Vue.extend({
   methods: {
     goToSearch: function (query) {
       const appWidth = $(window).width()
+      this.discardSuggestionsDataOnArrival = true
 
       if (appWidth <= 680) {
         const searchContainer = $('.searchContainer').get(0)
@@ -102,6 +104,7 @@ export default Vue.extend({
     },
 
     getSearchSuggestionsDebounce: function (query) {
+      this.discardSuggestionsDataOnArrival = false
       if (this.enableSearchSuggestions) {
         this.debounceSearchResults(query)
       }
@@ -125,7 +128,7 @@ export default Vue.extend({
       }
 
       ytSuggest(query).then((results) => {
-        this.searchSuggestionsDataList = results
+        this.setSearchSuggestionData(results)
       })
     },
 
@@ -146,7 +149,7 @@ export default Vue.extend({
       this.$store
         .dispatch('invidiousAPICall', searchPayload)
         .then((results) => {
-          this.searchSuggestionsDataList = results.suggestions
+          this.setSearchSuggestionData(results.suggestions)
         })
         .error((err) => {
           console.log(err)
@@ -157,6 +160,14 @@ export default Vue.extend({
             this.getSearchSuggestionsLocal(query)
           }
         })
+    },
+
+    setSearchSuggestionData: function (data) {
+      if (this.discardSuggestionsDataOnArrival) {
+        this.discardSuggestionsDataOnArrival = false
+      } else {
+        this.searchSuggestionsDataList = data
+      }
     },
 
     toggleSearchContainer: function () {

--- a/src/renderer/components/top-nav/top-nav.js
+++ b/src/renderer/components/top-nav/top-nav.js
@@ -128,7 +128,7 @@ export default Vue.extend({
       }
 
       ytSuggest(query).then((results) => {
-        this.setSearchSuggestionData(results)
+        this.setSearchSuggestionsData(results)
       })
     },
 
@@ -149,7 +149,7 @@ export default Vue.extend({
       this.$store
         .dispatch('invidiousAPICall', searchPayload)
         .then((results) => {
-          this.setSearchSuggestionData(results.suggestions)
+          this.setSearchSuggestionsData(results.suggestions)
         })
         .error((err) => {
           console.log(err)
@@ -162,7 +162,7 @@ export default Vue.extend({
         })
     },
 
-    setSearchSuggestionData: function (data) {
+    setSearchSuggestionsData: function (data) {
       if (this.discardSuggestionsDataOnArrival) {
         this.discardSuggestionsDataOnArrival = false
       } else {


### PR DESCRIPTION
The search suggestions popup sometimes appears after the user has already confirmed the search query.

This happens when the user pressed enter before the background query for the suggestions has finished. The query would finish during or even after the actual search query, populating the search suggestions data which would make the popup appear. The popup would then block the view on the first results, requiring the user the manually close the popup by clicking on some empty space.

I hope my approach on this issue is okay.