### PR TITLE
Fix undesired search suggestions popup

### DIFF
--- a/src/renderer/components/top-nav/top-nav.js
+++ b/src/renderer/components/top-nav/top-nav.js
@@ -78,6 +78,9 @@ export default Vue.extend({
         const searchContainer = $('.searchContainer').get(0)
         searchContainer.blur()
         searchContainer.style.display = 'none'
+      } else {
+        const searchInput = $('.searchInput input').get(0)
+        searchInput.blur()
       }
 
       this.$store.dispatch('getVideoIdFromUrl', query).then((result) => {


### PR DESCRIPTION
The search suggestions popup sometimes appears after the user has already confirmed the search query.

This happens when the user pressed enter before the background query for the suggestions has finished. The query would finish during or even after the actual search query, populating the search suggestions data which would make the popup appear. The popup would then block the view on the first results, requiring the user the manually close the popup by clicking on some empty space.

This PR tries a different approach than the PR #96. Credit goes to @PrestonN for the suggestion.