### PR TITLE
Fix for missing storyboards in dev mode

### DIFF
--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -653,11 +653,14 @@ export default Vue.extend({
         if (this.isDev) {
           fileLocation = `storyboards/${this.videoId}.vtt`
           uriSchema = fileLocation
+          // if the location does not exist, writeFileSync will not create the directory, so we have to do that manually
+          if (!fs.existsSync('storyboards/')) {
+            fs.mkdirSync('storyboards/')
+          }
         } else {
           fileLocation = `${userData}/storyboards/${this.videoId}.vtt`
           uriSchema = `file://${fileLocation}`
         }
-
         fs.writeFileSync(fileLocation, results)
 
         this.videoStoryboardSrc = uriSchema


### PR DESCRIPTION
The directory 'storyboards/' has to exist in order for the writeFileSync function to work. However the directory wasn't always available in dev mode, so now the app checks it's existence and can create it.