### PR TITLE
Short videos can now be played via local DASH.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20281,9 +20281,9 @@
       }
     },
     "yt-dash-manifest-generator": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/yt-dash-manifest-generator/-/yt-dash-manifest-generator-1.0.2.tgz",
-      "integrity": "sha512-rcBsAAhwlxtW/9irXRbU8N/8Qpft96OO0pLFvF8O7nDrjRWljnJC+DheXuhYGXpMqJGksROH1xQ1bHpwwp310g==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/yt-dash-manifest-generator/-/yt-dash-manifest-generator-1.1.0.tgz",
+      "integrity": "sha512-kLYeroH5LmdlvoRf4PrYyzgR5+tFaB1COSsLOjKHPnDvHQ+0Vp+c258TYR0WQp2RNpW57DYci9WG3O8+b1FQzQ==",
       "requires": {
         "xml-js": "^1.6.11",
         "ytdl-core": "^3.2.2"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "youtube-comments-task": "^1.3.15",
     "youtube-suggest": "^1.1.0",
     "yt-channel-info": "^1.1.0",
-    "yt-dash-manifest-generator": "^1.0.2",
+    "yt-dash-manifest-generator": "^1.1.0",
     "yt-trending-scraper": "^1.0.3",
     "yt-xml2vtt": "^1.1.2",
     "ytdl-core": "^3.2.2",

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -290,7 +290,7 @@ export default Vue.extend({
           } else {
             this.videoLengthSeconds = parseInt(result.videoDetails.lengthSeconds)
             this.videoSourceList = result.player_response.streamingData.formats
-            this.dashSrc = await this.createLocalDashManifest(result.formats)
+            this.dashSrc = await this.createLocalDashManifest(result.player_response.streamingData.adaptiveFormats)
 
             this.audioSourceList = result.player_response.streamingData.adaptiveFormats.filter((format) => {
               return format.mimeType.includes('audio')
@@ -627,7 +627,6 @@ export default Vue.extend({
         }
       }
       fs.writeFileSync(fileLocation, xmlData)
-      console.log('CREATED FILE')
       return [
         {
           url: uriSchema,


### PR DESCRIPTION
Updated DashGenerator and changed the used video formats for the local dash generation from formats to adaptiveFormats.

The change in provided formats gives the node module for at least some codecs Initialization data so that it can be used by the video player. Therefore even short videos (<1min) can be watched with the local DASH file.

However codecs without this data are still dropped in the package.