### PR TITLE
Fixing missing storyboards when using installation

### DIFF
--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -693,6 +693,9 @@ export default Vue.extend({
             fs.mkdirSync('storyboards/')
           }
         } else {
+          if (!fs.existsSync(`${userData}/storyboards/`)) {
+            fs.mkdirSync(`${userData}/storyboards/`)
+          }
           fileLocation = `${userData}/storyboards/${this.videoId}.vtt`
           uriSchema = `file://${fileLocation}`
         }


### PR DESCRIPTION
No check whether the directory for the storyboards exists. This leads to errors in case it is missing