### PR TITLE
VideoJS-VTT-Thumbnails module update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15583,8 +15583,7 @@
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
-      "dev": true
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
     },
     "process-nextick-args": {
       "version": "2.0.0",
@@ -18916,14 +18915,60 @@
       "resolved": "https://registry.npmjs.org/videojs-swf/-/videojs-swf-5.4.1.tgz",
       "integrity": "sha1-IHfvccdJ8seCPvSbq65N0qywj4c="
     },
-    "videojs-vtt-thumbnails": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/videojs-vtt-thumbnails/-/videojs-vtt-thumbnails-0.0.13.tgz",
-      "integrity": "sha512-7VGcpTRF+ppIss/NiZcDkVOE02k/GoMltxUumQ2jaTpR1ZieYTM+dPopmTXubLxOgUP3F71uTLMZVnWEtiHjVA==",
+    "videojs-vtt-thumbnails-fork": {
+      "version": "github:gilgusmaximus/videojs-vtt-thumbnails#9186e32823390328a62cf7d2fd5206d7349ea31e",
+      "from": "github:gilgusmaximus/videojs-vtt-thumbnails#build",
       "requires": {
-        "global": "^4.3.2",
-        "request": "^2.83.0",
-        "video.js": "^5.19.2 || ^6.6.0 || ^7.2.0"
+        "global": "^4.4.0",
+        "request": "^2.88.2",
+        "video.js": "^7.2.0 || ^6.6.0"
+      },
+      "dependencies": {
+        "global": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
+          "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
+          "requires": {
+            "min-document": "^2.19.0",
+            "process": "^0.11.10"
+          }
+        },
+        "request": {
+          "version": "2.88.2",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+          "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.8.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.6",
+            "extend": "~3.0.2",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.2",
+            "har-validator": "~5.1.3",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.19",
+            "oauth-sign": "~0.9.0",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.2",
+            "safe-buffer": "^5.1.2",
+            "tough-cookie": "~2.5.0",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.3.2"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+          "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+          "requires": {
+            "psl": "^1.1.28",
+            "punycode": "^2.1.1"
+          }
+        }
       }
     },
     "videojs-vtt.js": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "videojs-contrib-quality-levels": "^2.0.9",
     "videojs-http-source-selector": "^1.1.6",
     "videojs-replay": "^1.1.0",
-    "videojs-vtt-thumbnails": "0.0.13",
+    "videojs-vtt-thumbnails-fork": "github:gilgusmaximus/videojs-vtt-thumbnails#build",
     "vue": "^2.6.12",
     "vue-electron": "^1.0.6",
     "vue-i18n": "^8.21.0",

--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -7,7 +7,7 @@ import $ from 'jquery'
 // Need to expirement with both of them to see which one will work best.
 import videojs from 'video.js'
 import qualitySelector from '@silvermine/videojs-quality-selector'
-import 'videojs-vtt-thumbnails'
+import 'videojs-vtt-thumbnails-fork'
 import 'videojs-contrib-quality-levels'
 import 'videojs-http-source-selector'
 // import mediaelement from 'mediaelement'


### PR DESCRIPTION
Create a building branch in my fork where the dist folder is pushed as well.
This allows Freetube to use the Github repository to use as a source for the built module.

This PR fixes most of the fixable vulnerabilities in the module and therefore uses most up to date dependencies.
It also closes #101 because that was already fixed in the Repository of the code, but not applied due to the missing update on npm