### PR TITLE
Fix of the ft-video-list display since release from streams

### DIFF
--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -269,6 +269,10 @@ const actions = {
       return payload.publishText
     }
     const strings = payload.publishText.split(' ')
+    // filters out the streamed x hours ago and removes the streamed in order to keep the rest of the code working
+    if (strings[0].toLowerCase() === 'streamed') {
+      strings.shift()
+    }
     const singular = (strings[0] === '1')
     let publicationString = payload.templateString.replace('$', strings[0])
     switch (strings[1].substring(0, 2)) {


### PR DESCRIPTION
The error was that the string for Streamed from ytdl contains the 'Streamed' before the string that is actually processed.
So I shifted that thing out.
The error it fixes:
![image](https://user-images.githubusercontent.com/34301369/92036206-26b90080-ed70-11ea-8a8f-0770673e7601.png)
