### PR TITLE
Settings page a11y - enabled tab navigation to switches

### DIFF
--- a/src/renderer/components/ft-toggle-switch/ft-toggle-switch.sass
+++ b/src/renderer/components/ft-toggle-switch/ft-toggle-switch.sass
@@ -1,21 +1,22 @@
 /* Thanks to Guus Lieben for the Material Design Switch */
 
 .switch-ctn
+  margin: 20px 16px
   position: relative
+
+  &.compact
+    margin: 0
 
 .switch-input
   appearance: none
   height: 20px
-  left: 13px
+  left: -3px
   position: absolute
   top: calc(50% - 3px)
   -ms-transform: translate(0, (-50%))
   -webkit-transform: translate(0, -50%)
   transform: translate(0, -50%)
   width: 34px
-
-  &.compact
-    left: -3px
 
 .switch-label
   position: relative
@@ -24,12 +25,7 @@
   cursor: pointer
   font-weight: 500
   text-align: left
-  margin: 16px
-  padding: 16px 0 16px 44px
-
-  &.compact
-    margin: 0px
-    padding: 12px 0 12px 44px
+  padding: 12px 0 12px 44px
 
   &:before, &:after
     content: ""

--- a/src/renderer/components/ft-toggle-switch/ft-toggle-switch.sass
+++ b/src/renderer/components/ft-toggle-switch/ft-toggle-switch.sass
@@ -8,6 +8,8 @@
     margin: 0
 
 .switch-input
+  -moz-appearance: none
+  -webkit-appearance: none
   appearance: none
   height: 20px
   left: -3px

--- a/src/renderer/components/ft-toggle-switch/ft-toggle-switch.sass
+++ b/src/renderer/components/ft-toggle-switch/ft-toggle-switch.sass
@@ -6,7 +6,7 @@
 .switch-input
   appearance: none
   height: 20px
-  left: -3px
+  left: 13px
   position: absolute
   top: calc(50% - 3px)
   -ms-transform: translate(0, (-50%))
@@ -15,6 +15,7 @@
   width: 34px
 
 .switch-label
+  position: relative
   display: inline-block
   min-width: 112px
   cursor: pointer

--- a/src/renderer/components/ft-toggle-switch/ft-toggle-switch.sass
+++ b/src/renderer/components/ft-toggle-switch/ft-toggle-switch.sass
@@ -14,6 +14,9 @@
   transform: translate(0, -50%)
   width: 34px
 
+  &.compact
+    left: -3px
+
 .switch-label
   position: relative
   display: inline-block

--- a/src/renderer/components/ft-toggle-switch/ft-toggle-switch.sass
+++ b/src/renderer/components/ft-toggle-switch/ft-toggle-switch.sass
@@ -1,10 +1,20 @@
 /* Thanks to Guus Lieben for the Material Design Switch */
 
+.switch-ctn
+  position: relative
+
 .switch-input
-  display: none
+  appearance: none
+  height: 20px
+  left: -3px
+  position: absolute
+  top: calc(50% - 3px)
+  -ms-transform: translate(0, (-50%))
+  -webkit-transform: translate(0, -50%)
+  transform: translate(0, -50%)
+  width: 34px
 
 .switch-label
-  position: relative
   display: inline-block
   min-width: 112px
   cursor: pointer

--- a/src/renderer/components/ft-toggle-switch/ft-toggle-switch.vue
+++ b/src/renderer/components/ft-toggle-switch/ft-toggle-switch.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="switch-ctn">
     <input
       :id="id"
       v-model="currentValue"

--- a/src/renderer/components/ft-toggle-switch/ft-toggle-switch.vue
+++ b/src/renderer/components/ft-toggle-switch/ft-toggle-switch.vue
@@ -1,19 +1,20 @@
 <template>
-  <div class="switch-ctn">
+  <div
+    class="switch-ctn"
+    :class="{compact}"
+  >
     <input
       :id="id"
       v-model="currentValue"
       type="checkbox"
       name="set-name"
       class="switch-input"
-      :class="{compact}"
       :checked="currentValue"
       @change="$emit('change', currentValue)"
     >
     <label
       :for="id"
       class="switch-label"
-      :class="{compact}"
     >
       {{ label }}
     </label>

--- a/src/renderer/components/ft-toggle-switch/ft-toggle-switch.vue
+++ b/src/renderer/components/ft-toggle-switch/ft-toggle-switch.vue
@@ -6,6 +6,7 @@
       type="checkbox"
       name="set-name"
       class="switch-input"
+      :class="{compact}"
       :checked="currentValue"
       @change="$emit('change', currentValue)"
     >


### PR DESCRIPTION
### Issues
- ft-toggle-switch components have the input element styled with display: none, preventing keyboard accessible navigation to them

### Changes Made
- Modified ft-toggle-switch component to have the input visually hidden behind the graphical switch instead of it being set to display: none
  - Exact positioning adjusted to keep the focus outline in the right place