### PR TITLE
Missing video formats due to region lock

### DIFF
--- a/src/renderer/components/watch-video-comments/watch-video-comments.js
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.js
@@ -93,7 +93,7 @@ export default Vue.extend({
           comment.showReplies = false
           comment.dataType = 'local'
           this.toLocalePublicationString({
-            publishText: (comment.time + 'ago'),
+            publishText: (comment.time + ' ago'),
             templateString: this.$t('Video.Publicationtemplate'),
             timeStrings: this.$t('Video.Published'),
             liveStreamString: this.$t('Video.Watching'),

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -302,6 +302,7 @@ export default Vue.extend({
                 message: this.$t('This video is unavailable because of missing formats. This can happen due to country unavailability.'),
                 time: 7000
               })
+              this.handleVideoEnded()
               return
             }
 

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -294,7 +294,16 @@ export default Vue.extend({
             }
           } else {
             this.videoLengthSeconds = parseInt(result.videoDetails.lengthSeconds)
-            this.videoSourceList = result.player_response.streamingData.formats.reverse()
+            if (result.player_response.streamingData !== undefined) {
+              this.videoSourceList = result.player_response.streamingData.formats.reverse()
+            } else {
+              // video might be region locked or something else. This leads to no formats being available
+              this.showToast({
+                message: this.$t('This video is unavailable because of missing formats. This can happen due to country unavailability.'),
+                time: 7000
+              })
+              return
+            }
 
             if (typeof result.player_response.streamingData.adaptiveFormats !== 'undefined') {
               this.dashSrc = await this.createLocalDashManifest(result.player_response.streamingData.adaptiveFormats)

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -479,6 +479,7 @@ Local API Error (Click to copy): Lokaler API Fehler (Klicke zum Kopieren)
 Invidious API Error (Click to copy): Invidious API Fehler (Klicke zum Kopieren)
 Falling back to Invidious API: Falle auf Invidious API zurück
 Falling back to the local API: Dalle auf lokale API zurück
+This video is unavailable because of missing formats. This can happen due to country unavailability.: Dieses Video ist aufgrund fehlernder Formate nicht verfügbar. Dies kann zum Beispiel durch Zugriffsbeschränkungen für Länder geschehen.
 Subscriptions have not yet been implemented: Abonnements sind noch nicht implementiert
 Loop is now disabled: Schleife ist jetzt deaktiviert
 Loop is now enabled: Schleife ist jetzt aktiviert

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -492,6 +492,7 @@ Local API Error (Click to copy): Local API Error (Click to copy)
 Invidious API Error (Click to copy): Invidious API Error (Click to copy)
 Falling back to Invidious API: Falling back to Invidious API
 Falling back to the local API: Falling back to the local API
+This video is unavailable because of missing formats. This can happen due to country unavailability.: This video is unavailable because of missing formats. This can happen due to country unavailability.
 Subscriptions have not yet been implemented: Subscriptions have not yet been implemented
 Loop is now disabled: Loop is now disabled
 Loop is now enabled: Loop is now enabled


### PR DESCRIPTION
Added a check whether the video returns formats that can be used to view
the video. If not, this might be due to region locks. At the moment the
code just returns. 

For playlists this will likely not be so great because they will still stop. So a somewhat handling for region locked videos in playlists is still necessary, so that the playlist plays on after skipping.

Addresses #173 